### PR TITLE
initial contextListener changes

### DIFF
--- a/packages/fdc3-standard/src/api/ContextListenerHandlerInvocationMode.ts
+++ b/packages/fdc3-standard/src/api/ContextListenerHandlerInvocationMode.ts
@@ -1,17 +1,17 @@
 // invocation mode for addContextListener 
-// - single: when the app joins a channel, invoke the handler ONLY ONCE, with the latest context on the channel, regardless of type
-//      given these example previous broadcasts in the channel:
+// - single: when the app joins a channel, the context listener handler will be invoked ONLY ONCE, with the latest context on the channel, regardless of type
+//      Scenario - the following contexts were previously broadcast in the channel:
 //          - fdc3.instrument
 //          - fdc3.instrumentList
 //          - fdc3.contact
 //      the handler will be invoked once with the latest context type, which is fdc3.contact.
-// - multiple: invoke handler once for each context type available in the channel.
-//      given these example previous broadcasts in the channel:
+// - multiple: the context listener handler will be invoked once with the latest context for each context type available in the channel.
+//      Scenario - the following contexts were previously broadcast in the channel:
 //          - fdc3.instrument
 //          - fdc3.instrumentList
 //          - fdc3.contact
-//      the handler will be invoked three times, once for each context type:
-//          - first with fdc3.instrument
+//      the handler will be invoked three times, once for each context type, in the following order (Last In First Out):
+//          - first with fdc3.contact
 //          - then with fdc3.instrumentList
-//          - finally with fdc3.contact
-export type HandlerInvocationMode = 'single' | 'multiple';
+//          - finally with fdc3.instrument 
+export type ContextListenerInvocationMode = 'Single' | 'Multiple';

--- a/packages/fdc3-standard/src/api/ContextListenerHandlerInvocationMode.ts
+++ b/packages/fdc3-standard/src/api/ContextListenerHandlerInvocationMode.ts
@@ -1,0 +1,17 @@
+// invocation mode for addContextListener 
+// - single: when the app joins a channel, invoke the handler ONLY ONCE, with the latest context on the channel, regardless of type
+//      given these example previous broadcasts in the channel:
+//          - fdc3.instrument
+//          - fdc3.instrumentList
+//          - fdc3.contact
+//      the handler will be invoked once with the latest context type, which is fdc3.contact.
+// - multiple: invoke handler once for each context type available in the channel.
+//      given these example previous broadcasts in the channel:
+//          - fdc3.instrument
+//          - fdc3.instrumentList
+//          - fdc3.contact
+//      the handler will be invoked three times, once for each context type:
+//          - first with fdc3.instrument
+//          - then with fdc3.instrumentList
+//          - finally with fdc3.contact
+export type HandlerInvocationMode = 'single' | 'multiple';

--- a/packages/fdc3-standard/src/api/DesktopAgent.ts
+++ b/packages/fdc3-standard/src/api/DesktopAgent.ts
@@ -16,6 +16,7 @@ import { AppMetadata } from './AppMetadata';
 import { Intent } from '../intents/Intents';
 import { ContextType } from '../context/ContextType';
 import { EventHandler, FDC3EventTypes } from './Events';
+import { HandlerInvocationMode } from './ContextListenerHandlerInvocationMode';
 
 /**
  * A Desktop Agent is a desktop component (or aggregate of components) that serves as a
@@ -362,10 +363,14 @@ export interface DesktopAgent {
    *
    * ```javascript
    * // any context
-   * const listener = await fdc3.addContextListener(null, context => { ... });
+   * const listener = await fdc3.addContextListener(null, context => { ... });*
+   * 
+   * // listener for a subset of types
+   * const contactListener = await fdc3.addContextListener(['fdc3.instrument', 'fdc3.instrumentList'], context => { ... });
    *
    * // listener for a specific type
    * const contactListener = await fdc3.addContextListener('fdc3.contact', contact => { ... });
+   * 
    *
    * // listener that logs metadata for the message a specific type
    * const contactListener = await fdc3.addContextListener('fdc3.contact', (contact, metadata) => {
@@ -374,7 +379,7 @@ export interface DesktopAgent {
    * });
    * ```
    */
-  addContextListener(contextType: ContextType | null, handler: ContextHandler): Promise<Listener>;
+  addContextListener(contextType: ContextType | ContextType[] | null, handler: ContextHandler, invocationMode?: HandlerInvocationMode): Promise<Listener>;
 
   /**
    * Register a handler for events from the Desktop Agent. Whenever the handler function

--- a/packages/fdc3-standard/src/api/DesktopAgent.ts
+++ b/packages/fdc3-standard/src/api/DesktopAgent.ts
@@ -360,6 +360,10 @@ export interface DesktopAgent {
    * Context may also be received via this listener if the application was launched via a call to  `fdc3.open`, where context was passed as an argument. In order to receive this, applications SHOULD add their context listener as quickly as possible after launch, or an error MAY be returned to the caller and the context may not be delivered. The exact timeout used is set by the Desktop Agent implementation, but MUST be at least 15 seconds.
    *
    * Optional metadata about the context message, including the app that originated the message, SHOULD be provided by the desktop agent implementation.
+   * 
+   * Optional invocationMode can be specified to control how the handler is invoked when the app joins a channel. 
+   * A null value should be treated by the DA as `single`, which means the handler will be invoked only once with the latest context on the channel, regardless of type. 
+   * If `multiple` is specified, the handler will be invoked once for each context type available in the channel.
    *
    * ```javascript
    * // any context

--- a/packages/fdc3-standard/src/api/DesktopAgent.ts
+++ b/packages/fdc3-standard/src/api/DesktopAgent.ts
@@ -16,7 +16,7 @@ import { AppMetadata } from './AppMetadata';
 import { Intent } from '../intents/Intents';
 import { ContextType } from '../context/ContextType';
 import { EventHandler, FDC3EventTypes } from './Events';
-import { HandlerInvocationMode } from './ContextListenerHandlerInvocationMode';
+import { ContextListenerInvocationMode } from './ContextListenerHandlerInvocationMode';
 
 /**
  * A Desktop Agent is a desktop component (or aggregate of components) that serves as a
@@ -353,28 +353,80 @@ export interface DesktopAgent {
   addIntentListener(intent: Intent, handler: IntentHandler): Promise<Listener>;
 
   /**
-   * Adds a listener for incoming context broadcasts from the Desktop Agent (via a User channel or `fdc3.open`API call. If the consumer is only interested in a context of a particular type, they can they can specify that type. If the consumer is able to receive context of any type or will inspect types received, then they can pass `null` as the `contextType` parameter to receive all context types.
-   *
-   * Context broadcasts are primarily received from apps that are joined to the same User Channel as the listening application, hence, if the application is not currently joined to a User Channel no broadcasts will be received from channels. If this function is called after the app has already joined a channel and the channel already contains context that would be passed to the context listener, then it will be called immediately with that context.
-   *
-   * Context may also be received via this listener if the application was launched via a call to  `fdc3.open`, where context was passed as an argument. In order to receive this, applications SHOULD add their context listener as quickly as possible after launch, or an error MAY be returned to the caller and the context may not be delivered. The exact timeout used is set by the Desktop Agent implementation, but MUST be at least 15 seconds.
-   *
-   * Optional metadata about the context message, including the app that originated the message, SHOULD be provided by the desktop agent implementation.
    * 
-   * Optional invocationMode can be specified to control how the handler is invoked when the app joins a channel. 
-   * A null value should be treated by the DA as `single`, which means the handler will be invoked only once with the latest context on the channel, regardless of type. 
-   * If `multiple` is specified, the handler will be invoked once for each context type available in the channel.
-   *
-   * ```javascript
+   * Adds a listener for incoming context broadcasts from the Desktop Agent (via a User channel or `fdc3.open` API call). If the consumer is only interested in one or more contexts of a particular type, they can specify such types, either by specifying a single `contextType` or an array of `contextType`. If the consumer is able to receive context of any type or will inspect types received, then they can pass `null` as the `contextType` parameter to receive all context types.
+   * 
+   * Context broadcasts are primarily received from apps that are joined to the same User Channel as the listening application, hence, if the application is not currently joined to a User Channel no broadcasts will be received from User channels. 
+   * 
+   * If this function is called after the app has already joined a channel and the channel already contains context that matches the type of the context listener, then it will be called immediately and the context passed to the handler function.
+   * 
+   * Using the third optional parameter `invocationMode`, the application can specify two different ways for how the Desktop Agent invokes its contextHandler when the app joins a channel:
+   * 
+   * ### Single  
+   * The registered context handler method will be invoked only once with the latest context type. If `null` or `contextType[]` was passed as the context type for the listener and the channel contains multiple context types availabe, then the handler function will be called immediately with the single most recent context - regardless of type. Only one invocation will be made.
+   * 
+   * ```ts
+   * 11:00 App A and App B both join channel green
+   * 11.01 App A broadcasts an instrument
+   * 11.02 App A broadcasts an instrumentList
+   * 11.03 App B broadcasts a contact
+   * 11.04 App C adds a context handler: await fdc3.addContextListener(null, context => { ... }, HandlerInvocationMode.Single);
+   * 11.05 App C joins channel green
+   * ```
+   * 
+   * App C should have the context handler being invoked 1 time with:
+   * 
+   * ```ts
+   * fdc3.contact
+   * ```
+   * 
+   * ### Multiple
+   * If a single `contextType` is specified, the behavior should be the same as `HandlerInvocationMode.Single`.
+   * 
+   * If `null` or a `contextType[]` is provided, when the app joins a channel the handler is invoked exactly once per type, supplying only the latest context for each type available in the channel.
+   * 
+   * The Desktop Agent MUST make the invocations in an ordered manner: the handler is first called for the `contextType` whose context arrived most recently, then for earlier types in reverse arrival order.
+   * 
+   * Given the following broadcasts to a channel:
+   * 
+   * ```ts
+   * 11:00 App A and App B both join channel green
+   * 11.01 App A broadcasts an instrument
+   * 11.02 App A broadcasts an instrumentList
+   * 11.03 App B broadcasts a contact
+   * 11.04 App C adds a context handler: await fdc3.addContextListener(null, context => { ... }, HandlerInvocationMode.Multiple);
+   * 11.05 App C joins channel green
+   * ```
+   * 
+   * App C should have the context handler being invoked 3 times in the following order:
+   * 
+   * ```ts
+   * fdc3.contact
+   * fdc3.instrumentList
+   * fdc3.instrument
+   * ```
+   * 
+   * By default, if no mode is specified, the Desktop Agent MUST treat it as a `Single` mode listener
+   * 
+   * Context may also be received via this listener if the application was launched via a call to  [`fdc3.open`](#open), where context was passed as an argument. In order to receive this, applications SHOULD add their context listener as quickly as possible after launch, or an error MAY be returned to the caller and the context may not be delivered. The exact timeout used is set by the Desktop Agent implementation, but MUST be at least 15 seconds.
+   * 
+   * Optional metadata about each context message received, including the app that originated the message, SHOULD be provided by the Desktop Agent implementation.
+   * **Examples:**
+   * ```js
    * // any context
-   * const listener = await fdc3.addContextListener(null, context => { ... });*
-   * 
-   * // listener for a subset of types
-   * const contactListener = await fdc3.addContextListener(['fdc3.instrument', 'fdc3.instrumentList'], context => { ... });
+   * const listener = await fdc3.addContextListener(null, context => { ... });
    *
    * // listener for a specific type
    * const contactListener = await fdc3.addContextListener('fdc3.contact', contact => { ... });
-   * 
+   *
+   * // listener for a limited subset of types - Only one invocation will be made when the app joins a channel
+   * const singleModeListener = await fdc3.addContextListener(['fdc3.instrument', 'fdc3.instrumentList'], context => { ... }, HandlerInvocationMode.Single);
+   *
+   * // Not passing a HandlerInvocationMode will have the same result as setting it to Single as in the example above
+   * const noModeListener = await fdc3.addContextListener(['fdc3.instrument', 'fdc3.instrumentList'], context => { ... });
+   *
+   * // Specifying an array of context types with Multiple invocation mode, the listener will be invoked once for each of the types available in the channel upon joining it.
+   * const multipleModeListener = await fdc3.addContextListener(['fdc3.instrument', 'fdc3.instrumentList'], context => { ... }, HandlerInvocationMode.Multiple);
    *
    * // listener that logs metadata for the message a specific type
    * const contactListener = await fdc3.addContextListener('fdc3.contact', (contact, metadata) => {
@@ -383,7 +435,7 @@ export interface DesktopAgent {
    * });
    * ```
    */
-  addContextListener(contextType: ContextType | ContextType[] | null, handler: ContextHandler, invocationMode?: HandlerInvocationMode): Promise<Listener>;
+  addContextListener(contextType: ContextType | ContextType[] | null, handler: ContextHandler, invocationMode?: ContextListenerInvocationMode): Promise<Listener>;
 
   /**
    * Register a handler for events from the Desktop Agent. Whenever the handler function

--- a/website/docs/api/ref/DesktopAgent.md
+++ b/website/docs/api/ref/DesktopAgent.md
@@ -28,7 +28,7 @@ interface DesktopAgent {
 
   // context
   broadcast(context: Context): Promise<void>;
-  addContextListener(contextType: string | null, handler: ContextHandler): Promise<Listener>;
+  addContextListener(contextType: string[] | string | null, handler: ContextHandler, invocationMode?: HandlerInvocationMode): Promise<Listener>;
 
   // intents
   findIntent(intent: string, context?: Context, resultType?: string): Promise<AppIntent>;
@@ -76,7 +76,8 @@ interface IDesktopAgent
 
     // Context
     Task Broadcast(IContext context);
-    Task<IListener> AddContextListener<T>(string? contextType, ContextHandler<T> handler) where T : IContext;
+    Task<IListener> AddContextListener<T>(string? contextType, ContextHandler<T> handler, HandlerInvocationMode? invocationMode ) where T : IContext;
+    Task<IListener> AddContextListener<T>(string[] contextType, ContextHandler<T> handler, HandlerInvocationMode? invocationMode ) where T : IContext;
 
     // Intents
     Task<IAppIntent> FindIntent(string intent, IContext? context = null, string? resultType = null);
@@ -162,7 +163,7 @@ type IDesktopAgent interface {
 <TabItem value="ts" label="TypeScript/JavaScript">
 
 ```ts
-addContextListener(contextType: string | null, handler: ContextHandler): Promise<Listener>;
+addContextListener(contextType: string | string[] | null, handler: ContextHandler, invocationMode?: HandlerInvocationMode): Promise<Listener>;
 ```
 
 </TabItem>
@@ -184,9 +185,43 @@ func (desktopAgent *DesktopAgent) AddContextListener(contextType string, handler
 </TabItem>
 </Tabs>
 
-Adds a listener for incoming context broadcasts from the Desktop Agent (via a User channel or [`fdc3.open`](#open) API call). If the consumer is only interested in a context of a particular type, they can specify that type. If the consumer is able to receive context of any type or will inspect types received, then they can pass `null` as the `contextType` parameter to receive all context types.
+Adds a listener for incoming context broadcasts from the Desktop Agent (via a User channel or [`fdc3.open`](#open) API call). If the consumer is only interested in a context of a particular type, they can specify that type. If the consumer is capable of handling a known limited subset of context types, they can specify an array of `contextType` that they support. If the consumer is able to receive context of any type or will inspect types received, then they can pass `null` as the `contextType` parameter to receive all context types.
 
-Context broadcasts are primarily received from apps that are joined to the same User Channel as the listening application, hence, if the application is not currently joined to a User Channel no broadcasts will be received from User channels. If this function is called after the app has already joined a channel and the channel already contains context that matches the type of the context listener, then it will be called immediately and the context passed to the handler function. If `null` was passed as the context type for the listener and the channel contains context, then the handler function will be called immediately with the most recent context - regardless of type.
+Context broadcasts are primarily received from apps that are joined to the same User Channel as the listening application, hence, if the application is not currently joined to a User Channel no broadcasts will be received from User channels. 
+
+If this function is called after the app has already joined a channel and the channel already contains context that matches the type of the context listener, then it will be called immediately and the context passed to the handler function.
+
+Using the third optional parameter `invocationMode`, the application can specify two different ways for how the Desktop Agent invokes its contextHandler when the app joins a channel:
+
+### Single  
+The registered context handler method will be invoked only once with the latest context type. If `null` or `contextType[]` was passed as the context type for the listener and the channel contains multiple context types availabe, then the handler function will be called immediately with the single most recent context - regardless of type. Only one invocation will be made.
+
+### Multiple
+If a single `contextType` is specified, the behavior should be the same as `HandlerInvocationMode.Single`.  
+If `null` or a `contextType[]` is provided, when the app joins a channel the handler is invoked exactly once per type, supplying only the latest context for each.  
+
+The Desktop Agent MUST make the invocations in an ordered manner: the handler is first called for the `contextType` whose context arrived most recently, then for earlier types in reverse arrival order.  
+
+Given the following broadcasts to a channel:
+
+```ts
+11:00 App A and App B both join channel green
+11.01 App A broadcasts an instrument
+11.02 App A broadcasts an instrumentList
+11.03 App B broadcasts a contact
+11.04 App C adds a context handler: await fdc3.addContextListener(null, context => { ... }, HandlerInvocationMode.multiple);
+11.05 App C joins channel green
+```
+
+App C should have the context handler being invoked 3 times in the following order:
+
+```ts
+fdc3.contact
+fdc3.instrumentList
+fdc3.instrument
+```
+
+By default, if no mode is specified, the Desktop Agent MUST treat it as a `Single` mode lsitener
 
 Context may also be received via this listener if the application was launched via a call to  [`fdc3.open`](#open), where context was passed as an argument. In order to receive this, applications SHOULD add their context listener as quickly as possible after launch, or an error MAY be returned to the caller and the context may not be delivered. The exact timeout used is set by the Desktop Agent implementation, but MUST be at least 15 seconds.
 
@@ -203,6 +238,15 @@ const listener = await fdc3.addContextListener(null, context => { ... });
 
 // listener for a specific type
 const contactListener = await fdc3.addContextListener('fdc3.contact', contact => { ... });
+
+// listener for a limited subset of types - Only one invocation will be made when the app joins a channel
+const contactListener = await fdc3.addContextListener(['fdc3.instrument', 'fdc3.instrumentList'], contact => { ... }, HandlerInvocationMode.single);
+
+// Not passing a HandlerInvocationMode will have the same result as the example above
+const contactListener = await fdc3.addContextListener(['fdc3.instrument', 'fdc3.instrumentList'], contact => { ... });
+
+// Specifying 
+const contactListener = await fdc3.addContextListener(['fdc3.instrument', 'fdc3.instrumentList'], contact => { ... }, HandlerInvocationMode.multiple);
 
 // listener that logs metadata for the message a specific type
 const contactListener = await fdc3.addContextListener('fdc3.contact', (contact, metadata) => {

--- a/website/docs/api/ref/DesktopAgent.md
+++ b/website/docs/api/ref/DesktopAgent.md
@@ -185,7 +185,9 @@ func (desktopAgent *DesktopAgent) AddContextListener(contextType string, handler
 </TabItem>
 </Tabs>
 
-Adds a listener for incoming context broadcasts from the Desktop Agent (via a User channel or [`fdc3.open`](#open) API call). If the consumer is only interested in a context of a particular type, they can specify that type. If the consumer is capable of handling a known limited subset of context types, they can specify an array of `contextType` that they support. If the consumer is able to receive context of any type or will inspect types received, then they can pass `null` as the `contextType` parameter to receive all context types.
+
+
+Adds a listener for incoming context broadcasts from the Desktop Agent (via a User channel or [`fdc3.open`](#open) API call). If the consumer is only interested in one or more contexts of a particular type, they can specify such types, either by specifying a single `contextType` or an array of `contextType`. If the consumer is able to receive context of any type or will inspect types received, then they can pass `null` as the `contextType` parameter to receive all context types.
 
 Context broadcasts are primarily received from apps that are joined to the same User Channel as the listening application, hence, if the application is not currently joined to a User Channel no broadcasts will be received from User channels. 
 
@@ -196,11 +198,27 @@ Using the third optional parameter `invocationMode`, the application can specify
 ### Single  
 The registered context handler method will be invoked only once with the latest context type. If `null` or `contextType[]` was passed as the context type for the listener and the channel contains multiple context types availabe, then the handler function will be called immediately with the single most recent context - regardless of type. Only one invocation will be made.
 
-### Multiple
-If a single `contextType` is specified, the behavior should be the same as `HandlerInvocationMode.Single`.  
-If `null` or a `contextType[]` is provided, when the app joins a channel the handler is invoked exactly once per type, supplying only the latest context for each.  
+```ts
+11:00 App A and App B both join channel green
+11.01 App A broadcasts an instrument
+11.02 App A broadcasts an instrumentList
+11.03 App B broadcasts a contact
+11.04 App C adds a context handler: await fdc3.addContextListener(null, context => { ... }, HandlerInvocationMode.Single);
+11.05 App C joins channel green
+```
 
-The Desktop Agent MUST make the invocations in an ordered manner: the handler is first called for the `contextType` whose context arrived most recently, then for earlier types in reverse arrival order.  
+App C should have the context handler being invoked 1 time with:
+
+```ts
+fdc3.contact
+```
+
+### Multiple
+If a single `contextType` is specified, the behavior should be the same as `HandlerInvocationMode.Single`.
+
+If `null` or a `contextType[]` is provided, when the app joins a channel the handler is invoked exactly once per type, supplying only the latest context for each type available in the channel.
+
+The Desktop Agent MUST make the invocations in an ordered manner: the handler is first called for the `contextType` whose context arrived most recently, then for earlier types in reverse arrival order.
 
 Given the following broadcasts to a channel:
 
@@ -209,7 +227,7 @@ Given the following broadcasts to a channel:
 11.01 App A broadcasts an instrument
 11.02 App A broadcasts an instrumentList
 11.03 App B broadcasts a contact
-11.04 App C adds a context handler: await fdc3.addContextListener(null, context => { ... }, HandlerInvocationMode.multiple);
+11.04 App C adds a context handler: await fdc3.addContextListener(null, context => { ... }, HandlerInvocationMode.Multiple);
 11.05 App C joins channel green
 ```
 
@@ -221,7 +239,7 @@ fdc3.instrumentList
 fdc3.instrument
 ```
 
-By default, if no mode is specified, the Desktop Agent MUST treat it as a `Single` mode lsitener
+By default, if no mode is specified, the Desktop Agent MUST treat it as a `Single` mode listener
 
 Context may also be received via this listener if the application was launched via a call to  [`fdc3.open`](#open), where context was passed as an argument. In order to receive this, applications SHOULD add their context listener as quickly as possible after launch, or an error MAY be returned to the caller and the context may not be delivered. The exact timeout used is set by the Desktop Agent implementation, but MUST be at least 15 seconds.
 
@@ -240,13 +258,13 @@ const listener = await fdc3.addContextListener(null, context => { ... });
 const contactListener = await fdc3.addContextListener('fdc3.contact', contact => { ... });
 
 // listener for a limited subset of types - Only one invocation will be made when the app joins a channel
-const contactListener = await fdc3.addContextListener(['fdc3.instrument', 'fdc3.instrumentList'], contact => { ... }, HandlerInvocationMode.single);
+const singleModeListener = await fdc3.addContextListener(['fdc3.instrument', 'fdc3.instrumentList'], context => { ... }, HandlerInvocationMode.Single);
 
-// Not passing a HandlerInvocationMode will have the same result as the example above
-const contactListener = await fdc3.addContextListener(['fdc3.instrument', 'fdc3.instrumentList'], contact => { ... });
+// Not passing a HandlerInvocationMode will have the same result as setting it to Single as in the example above
+const noModeListener = await fdc3.addContextListener(['fdc3.instrument', 'fdc3.instrumentList'], context => { ... });
 
-// Specifying 
-const contactListener = await fdc3.addContextListener(['fdc3.instrument', 'fdc3.instrumentList'], contact => { ... }, HandlerInvocationMode.multiple);
+// Specifying an array of context types with Multiple invocation mode, the listener will be invoked once for each of the types available in the channel upon joining it.
+const multipleModeListener = await fdc3.addContextListener(['fdc3.instrument', 'fdc3.instrumentList'], context => { ... }, HandlerInvocationMode.Multiple);
 
 // listener that logs metadata for the message a specific type
 const contactListener = await fdc3.addContextListener('fdc3.contact', (contact, metadata) => {


### PR DESCRIPTION
## Describe your change

<!--- Describe your change here-->

### Related Issue
[Related to Issue 1616](https://github.com/finos/FDC3/issues/1616)

We at LSEG have considered a change to how the invocation of `addContextListener(null, handler)` should change to return the latest of each type published in the channel, the last entry being the latest to be broadcast.

We believe that this might be a breaking change for some applications since they might be expecting to receive only one invocation instead of many.

This is why we are suggesting the following changes to the API.

## Contributor License Agreement

<!--- All contributions to FDC3 must be made under an active contributor license agreement and the [Community Specification License](https://github.com/finos/FDC3/blob/main/LICENSE.md). This will be checked by the EasyCLA tool (https://easycla.lfx.linuxfoundation.org/) that runs automatically on every PR. If you've not contributed to FDC3 before, look for a comment on your PR shortly after it is raised and follow the instructions to establish a CLA or have it acknowledged by the EasyCLA tool. -->

- [x] I acknowledge that a contributor license agreement is required and that I have one in place or will seek to put one in place ASAP.

## Review Checklist

<!--- Checklist to be completed by reviewers, and pre-checked by the authors of a PR -->

- [x] **Issue**: If a change was made to the FDC3 Standard, was an issue linked above?
- [ ] **CHANGELOG**: Is a *CHANGELOG.md* entry included?
- [x] **API changes**: Does this PR include changes to any of the FDC3 APIs (`DesktopAgent`, `Channel`, `PrivateChannel`, `Listener`, `Bridging`)?
  - [x] **Docs & Sources**: If yes, were both documentation (/docs) and sources updated?<br/>
        *JSDoc comments on interfaces and types should be matched to the main documentation in /docs*
  - [ ] **Conformance tests**: If yes, are conformance test definitions (/toolbox/fdc3-conformance) still correct and complete?<br/>
        *Conformance test definitions should cover all **required** aspects of an FDC3 Desktop Agent implementation, which are usually marked with a **MUST** keyword, and  optional features (**SHOULD** or **MAY**) where the format of those features is defined*
  - [ ] **Schemas**: If yes, were changes applied to the Bridging and FDC3 for Web protocol schemas?<br/>
        *The Web Connection protocol and Desktop Agent Communication Protocol schemas must be able to support all necessary aspects of the Desktop Agent API, while Bridging must support those aspects necessary for Desktop Agents to communicate with each other*
    - [ ] If yes, was code generation (`npm run build`) run and the results checked in?<br/>
        *Generated code will be found at `/src/api/BrowserTypes.ts` and/or `/src/bridging/BridgingTypes.ts`*
- [ ] **Context types**: Were new Context type schemas created or modified in this PR?
  - [ ] Were the [field type conventions](https://fdc3.finos.org/docs/context/spec#field-type-conventions) adhered to?
  - [ ] Was the `BaseContext` schema applied via `allOf` (as it is in existing types)?
  - [ ] Was a `title` and `description` provided for all properties defined in the schema?
  - [ ] Was at least one example provided?
  - [ ] Was code generation (`npm run build`) run and the results checked in?<br/>
        *Generated code will be found at `/src/context/ContextTypes.ts`*
- [ ] **Intents**: Were new Intents created in this PR?
  - [ ] Were the [intent name prefixes](https://fdc3.finos.org/docs/intents/spec#intent-name-prefixes) and other [naming conventions & characteristics](https://fdc3.finos.org/docs/intents/spec#naming-conventions) adhered to?
  - [ ] Was the new intent added to the list in the [Intents Overview](https://fdc3.finos.org/docs/intents/spec#standard-intents)?
